### PR TITLE
Report ClientID for consumers

### DIFF
--- a/core/internal/consumer/kafka_client.go
+++ b/core/internal/consumer/kafka_client.go
@@ -462,6 +462,7 @@ func (module *KafkaClient) decodeAndSendGroupMetadata(valueVersion int16, group 
 					Partition:   partition,
 					Group:       group,
 					Owner:       member.ClientHost,
+					ClientID:    member.ClientID,
 				}, 1)
 			}
 		}

--- a/core/internal/consumer/kafka_client_test.go
+++ b/core/internal/consumer/kafka_client_test.go
@@ -435,6 +435,7 @@ func TestKafkaClient_decodeGroupMetadata(t *testing.T) {
 	assert.Equalf(t, int32(11), request.Partition, "Expected request sent with partition 0, not %v", request.Partition)
 	assert.Equalf(t, "testgroup", request.Group, "Expected request sent with Group testgroup, not %v", request.Group)
 	assert.Equalf(t, "testclienthost", request.Owner, "Expected request sent with Owner testclienthost, not %v", request.Owner)
+	assert.Equalf(t, "testclientid", request.ClientID, "Expected request set with ClientID testclientid, not %v", request.ClientID)
 }
 
 var decodeGroupMetadataErrors = []errorTestSetBytes{
@@ -493,6 +494,7 @@ func TestKafkaClient_processConsumerOffsetsMessage_Offset(t *testing.T) {
 	assert.Equalf(t, int32(11), request.Partition, "Expected request sent with partition 0, not %v", request.Partition)
 	assert.Equalf(t, "testgroup", request.Group, "Expected request sent with Group testgroup, not %v", request.Group)
 	assert.Equalf(t, "testclienthost", request.Owner, "Expected request sent with Owner testclienthost, not %v", request.Owner)
+	assert.Equalf(t, "testclientid", request.ClientID, "Expected request set with ClientID testclientid, no %v", request.ClientID)
 }
 
 func TestKafkaClient_processConsumerOffsetsMessage_Metadata(t *testing.T) {

--- a/core/internal/storage/inmemory_test.go
+++ b/core/internal/storage/inmemory_test.go
@@ -323,6 +323,7 @@ func TestInMemoryStorage_addConsumerOffset(t *testing.T) {
 	assert.Len(t, partitions, 1, "One partition not created")
 	assert.Equal(t, 10, partitions[0].offsets.Len(), "10 offset ring entries not created")
 	assert.Equal(t, "", partitions[0].owner, "Expected owner to be empty")
+	assert.Equal(t, "", partitions[0].clientID, "Expected clientID to be empty")
 
 	// All the ring values should be not nil
 	r := partitions[0].offsets
@@ -502,6 +503,7 @@ func TestInMemoryStorage_addConsumerOwner(t *testing.T) {
 		Group:       "testgroup",
 		Partition:   0,
 		Owner:       "testhost.example.com",
+		ClientID:    "test_client_id",
 	}
 	module.addConsumerOwner(&request, module.Log)
 
@@ -511,6 +513,7 @@ func TestInMemoryStorage_addConsumerOwner(t *testing.T) {
 	assert.True(t, ok, "Topic not created")
 	assert.Len(t, partitions, 1, "One partition not created")
 	assert.Equal(t, "testhost.example.com", partitions[0].owner, "Expected owner to be testhost.example.com, not %v", partitions[0].owner)
+	assert.Equal(t, "test_client_id", partitions[0].clientID, "Expected clientID to be test_client_id, not %v", partitions[0].clientID)
 }
 
 func TestInMemoryStorage_deleteTopic(t *testing.T) {
@@ -789,6 +792,7 @@ func TestInMemoryStorage_fetchConsumer(t *testing.T) {
 		Group:       "testgroup",
 		Partition:   0,
 		Owner:       "testhost.example.com",
+		ClientID:    "test_client_id",
 	}
 	module.addConsumerOwner(&request, module.Log)
 
@@ -811,6 +815,7 @@ func TestInMemoryStorage_fetchConsumer(t *testing.T) {
 	assert.Len(t, val["testtopic"], 1, "One partition for topic not returned")
 	assert.Equalf(t, uint64(2421), val["testtopic"][0].CurrentLag, "Expected current lag to be 2421, not %v", val["testtopic"][0].CurrentLag)
 	assert.Equalf(t, "testhost.example.com", val["testtopic"][0].Owner, "Expected owner to be testhost.example.com, not %v", val["testtopic"][0].Owner)
+	assert.Equalf(t, "test_client_id", val["testtopic"][0].ClientID, "Expected client_id to be test_client_id, not %v", val["testtopic"][0].ClientID)
 
 	offsets := val["testtopic"][0].Offsets
 	assert.Lenf(t, offsets, 10, "Expected to get 10 offsets for the partition, not %v", len(offsets))
@@ -929,6 +934,7 @@ func TestInMemoryStorage_fetchConsumersForTopic(t *testing.T) {
 		Group:       "testgroup",
 		Partition:   0,
 		Owner:       "testhost.example.com",
+		ClientID:    "test_client_id",
 	}
 	module.addConsumerOwner(&request, module.Log)
 
@@ -964,6 +970,7 @@ func TestInMemoryStorage_fetchConsumersForTopic_MultipleConsumers(t *testing.T) 
 		Group:       "testgroup",
 		Partition:   0,
 		Owner:       "testhost.example.com",
+		ClientID:    "test_client_id",
 	}
 	module.addConsumerOwner(&request, module.Log)
 	request = protocol.StorageRequest{
@@ -973,6 +980,7 @@ func TestInMemoryStorage_fetchConsumersForTopic_MultipleConsumers(t *testing.T) 
 		Group:       "testgroup2",
 		Partition:   0,
 		Owner:       "testhost.example.com",
+		ClientID:    "test_client_id",
 	}
 	module.addConsumerOwner(&request, module.Log)
 

--- a/core/protocol/evaluator.go
+++ b/core/protocol/evaluator.go
@@ -44,6 +44,9 @@ type PartitionStatus struct {
 	// If available (for active new consumers), the consumer host that currently owns this partiton
 	Owner string `json:"owner"`
 
+	// If available (for active new consumers), the client_id of the consumer that currently owns this partition
+	ClientID string `json:"client_id"`
+
 	// The status of the partition
 	Status StatusConstant `json:"status"`
 

--- a/core/protocol/storage.go
+++ b/core/protocol/storage.go
@@ -133,6 +133,9 @@ type StorageRequest struct {
 
 	// For StorageSetConsumerOwner requests, a string describing the consumer host that owns the partition
 	Owner string
+
+	// For StorageSetConsumerOwner requests, a string containing the client_id set by the consumer
+	ClientID string
 }
 
 // ConsumerPartition represents the information stored for a group for a single partition. It is used as part of the
@@ -150,6 +153,9 @@ type ConsumerPartition struct {
 	// A string that describes the consumer host that currently owns this partition, if the information is available
 	// (for active new consumers)
 	Owner string `json:"owner"`
+
+	// A string containing the client_id set by the consumer (for active new consumers)
+	ClientID string `json:"client_id"`
 
 	// The current number of messages that the consumer is behind for this partition. This is calculated using the
 	// last committed offset and the current broker end offset


### PR DESCRIPTION
Store and report ClientID for consumers, this is useful in environments where IPs are not ideal for identifying consumers. The ClientID is an ideal choice as it's user controlled so can be configured to be whatever the user finds most useful for correlation purposes.